### PR TITLE
allow command to be ran if syntax of view is Python (closes #11)

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -34,7 +34,8 @@ class BlackCommand(sublime_plugin.TextCommand):
 
     def run(self, edit: sublime.Edit):
         filename = self.view.file_name()
-        if filename and not filename.endswith(".py"):
+        python_syntax = "Python" in self.view.settings().get("syntax")
+        if (filename and not filename.endswith(".py")) and not python_syntax:
             sublime.status_message(
                 f"black: The current file is not a python script file: {filename}"
             )


### PR DESCRIPTION
This adds a validation path that checks if current view is Python.
The formatting command is now allowed to be executed if either of those is true:

1. filename extension is `.py`
2. current view's file path exists and syntax is set to `Python`
