### PR TITLE
fix: Change options to honer black CLI and toml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,24 @@ There are some modifiable properties in settings:
    //    - "smart": Automatic formatting is only enabled if there is a `black` section in the project's `pyproject.toml`
    "format_on_save": "on",
    // Black [OPTIONS]
+   // The priority of loading options for Black is:
+   // Sublime project settings > Configuration file > Sublime package user settings > Sublime package default settings
    "options": {
+      // Python versions that should be supported by Black's output.
       "target_version": [],
+      // How many characters per line to allow.
       "line_length": 88,
-      "string_normalization": true,
+      // Format all input files like typing stubs regardless of file extension (useful when piping source on standard input).
       "is_pyi": false,
-      "is_ipynb": false,
+      // Skip the first line of the source code.
       "skip_source_first_line": false,
-      "magic_trailing_comma": true,
-      "experimental_string_processing": false,
-      "python_cell_magics": [],
-      "preview": false
+      // Don't normalize string quotes or prefixes.
+      "skip_string_normalization": false,
+      // Don't use trailing commas as a reason to split lines.
+      "skip_magic_trailing_comma": false
    }
 }
+
 ```
 
 The `format_on_save` can also be toggled via `Preferences > Package Settings > Python Black > Format On Save`.
@@ -90,7 +95,7 @@ The Black options can also be configured in sublime-project:
         "python-black": {
             "options": {
                 "line_length": 127,
-                "string_normalization": false
+                "skip_string_normalization": true
             }
         }
     }

--- a/python-black.sublime-settings
+++ b/python-black.sublime-settings
@@ -15,13 +15,13 @@
       "target_version": [],
       // How many characters per line to allow.
       "line_length": 88,
-      // Normalize string quotes or prefixes.
-      "string_normalization": true,
       // Format all input files like typing stubs regardless of file extension (useful when piping source on standard input).
       "is_pyi": false,
       // Skip the first line of the source code.
       "skip_source_first_line": false,
-      // Use trailing commas as a reason to split lines.
-      "magic_trailing_comma": true,
+      // Don't normalize string quotes or prefixes.
+      "skip_string_normalization": false,
+      // Don't use trailing commas as a reason to split lines.
+      "skip_magic_trailing_comma": false
    }
 }

--- a/python_black/black.py
+++ b/python_black/black.py
@@ -142,10 +142,10 @@ def black_format_str(
     default_config: Optional[BlackConfig] = {
         "target_version": [],
         "line_length": DEFAULT_LINE_LENGTH,
-        "string_normalization": True,
         "is_pyi": False,
         "skip_source_first_line": False,
-        "magic_trailing_comma": True,
+        "skip_string_normalization": False,
+        "skip_magic_trailing_comma": False,
         "include": DEFAULT_INCLUDES,
     }
 
@@ -195,10 +195,10 @@ def black_format_str(
     mode = Mode(
         target_versions=versions,
         line_length=default_config["line_length"],
-        string_normalization=default_config["string_normalization"],
         is_pyi=default_config["is_pyi"],
         skip_source_first_line=default_config["skip_source_first_line"],
-        magic_trailing_comma=default_config["magic_trailing_comma"],
+        string_normalization=not default_config["skip_string_normalization"],
+        magic_trailing_comma=not default_config["skip_magic_trailing_comma"],
     )
 
     if code:


### PR DESCRIPTION
### Change summary
Change options to honer black CLI and toml config below:
1. `string_normalization` -> `skip_string_normalization`
2. `magic_trailing_comma` -> `skip_magic_trailing_comma`

Issue: #37 