### PR TITLE
rewrite imports using libcst

### DIFF
--- a/.libcst.codemod.yaml
+++ b/.libcst.codemod.yaml
@@ -1,0 +1,19 @@
+# String that LibCST should look for in code which indicates that the
+# module is generated code.
+generated_code_marker: "@generated"
+# Command line and arguments for invoking a code formatter. Anything
+# specified here must be capable of taking code via stdin and returning
+# formatted code via stdout.
+format_code: false
+# formatter: null
+# List of regex patterns which LibCST will evaluate against filenames to
+# determine if the module should be touched.
+blacklist_patterns: []
+# List of modules that contain codemods inside of them.
+modules:
+  # - "libcst.codemod.commands"
+  - "python_black.codemods"
+# Absolute or relative path of the repository root, used for providing
+# full-repo metadata. Relative paths should be specified with this file
+# location as the base.
+repo_root: "."

--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ logger.error("...")
 
 Discussion and creation of PRs are welcome.
 
+#### Updating vendored black library
+
+To update the vendored version of black, replace the `python_black/lib/black` and
+`python_black/lib/blib2to3` directories with the newer version.
+Once replaced, the imports need to be updated to point to the vendored version.
+This can be done automatically using libcst and the RewriteImportsCommand
+
+```bash
+python -m libcst.tool --no-format codemod import.RewriteImportsCommand --relative-to python_black.lib --replace black --replace blib2to3 --replace mypy_extensions --replace pathspec --replace platformdirs --replace packaging --replace tomli --replace typing_extensions --replace _black_version python_black/lib/black/
+python -m libcst.tool --no-format codemod import.RewriteImportsCommand --relative-to python_black.lib --replace black --replace blib2to3 --replace mypy_extensions --replace pathspec --replace platformdirs --replace packaging --replace tomli --replace typing_extensions --replace _black_version python_black/lib/blib2to3/
+```
+
 ### TODO
 
 - [ ] format all python files in the current project

--- a/python_black/codemods/import.py
+++ b/python_black/codemods/import.py
@@ -1,0 +1,71 @@
+import argparse
+
+import libcst as cst
+from libcst.codemod import CodemodContext, VisitorBasedCodemodCommand
+
+
+class RewriteImportsCommand(VisitorBasedCodemodCommand):
+    DESCRIPTION: str = "rewrite imports."
+
+    @staticmethod
+    def add_args(arg_parser: argparse.ArgumentParser) -> None:
+        # Add command-line args that a user can specify for running this
+        # codemod.
+        arg_parser.add_argument(
+            "--replace",
+            dest="replacements",
+            metavar="STRING",
+            help="modules to replacement",
+            action="append",
+            required=True,
+        )
+        arg_parser.add_argument(
+            "--relative-to",
+            dest="relative_to",
+            metavar="STRING",
+            help="make the imports point to this path",
+            required=True,
+        )
+
+    def __init__(
+        self, context: CodemodContext, replacements: list[str], relative_to: str
+    ) -> None:
+        super().__init__(context)
+        self.replacements = replacements
+        self.relative_to = relative_to
+
+    def _get_module_name(self, module: cst.Attribute | cst.Name) -> str | None:
+        if module is not None:
+            while isinstance(module, cst.Attribute):
+                module = module.value
+            return module.value
+        return None
+
+    def leave_ImportFrom(
+        self, original_node: cst.ImportFrom, updated_node: cst.ImportFrom
+    ) -> cst.ImportFrom:
+        if self._get_module_name(updated_node.module) in self.replacements:
+            extra_dots = self.context.full_package_name.removeprefix(self.relative_to).lstrip(".").count(".")
+            relative = [cst.Dot(), cst.Dot()] + [cst.Dot() for _ in range(extra_dots)]
+            return updated_node.with_changes(relative=relative)
+
+        return updated_node
+
+    def leave_Import(
+        self, original_node: cst.Import, updated_node: cst.Import
+    ) -> cst.Import:
+        for each in updated_node.names:
+            if self._get_module_name(each.name) in self.replacements:
+                if not isinstance(each.name, cst.Name):
+                    raise ValueError("Rewriting submodule imports not supported")
+                if len(updated_node.names) > 1:
+                    raise ValueError("Rewriting multiple imports on the same line is not supported")
+
+                relative_to, last = self.relative_to.rsplit(".", 1)
+                extra_dots = self.context.full_package_name.removeprefix(relative_to).lstrip(".").count(".")
+                return cst.ImportFrom(
+                    module=cst.Name(value=last),
+                    relative=[cst.Dot(), cst.Dot()] + [cst.Dot() for _ in range(extra_dots)],
+                    names=[each]
+                )
+        return updated_node


### PR DESCRIPTION
adds a helper utility based on libcst to do the rewriting of imports when updating black